### PR TITLE
Require MLMD to be deployed when using V2 Pipelines

### DIFF
--- a/api/v1alpha1/dspipeline_types.go
+++ b/api/v1alpha1/dspipeline_types.go
@@ -40,8 +40,7 @@ type DSPASpec struct {
 	// ObjectStorage specifies Object Store configurations, used for DS Pipelines artifact passing and storage. Specify either the your own External Storage (e.g. AWS S3), or use the default Minio deployment (unsupported, primarily for development, and testing) .
 	// +kubebuilder:validation:Required
 	*ObjectStorage `json:"objectStorage"`
-	// +kubebuilder:default:={deploy: true}
-	*MLMD `json:"mlmd,omitempty"`
+	*MLMD          `json:"mlmd,omitempty"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default:={deploy: false}
 	*CRDViewer `json:"crdviewer"`
@@ -261,7 +260,7 @@ type Minio struct {
 
 type MLMD struct {
 	// Enable DS Pipelines Operator management of MLMD. Setting Deploy to false disables operator reconciliation. Default: true
-	// +kubebuilder:default:=true
+	// +kubebuilder:default:=false
 	// +kubebuilder:validation:Optional
 	Deploy  bool `json:"deploy"`
 	*Envoy  `json:"envoy,omitempty"`

--- a/config/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
+++ b/config/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
@@ -305,11 +305,9 @@ spec:
                 default: v1
                 type: string
               mlmd:
-                default:
-                  deploy: true
                 properties:
                   deploy:
-                    default: true
+                    default: false
                     description: 'Enable DS Pipelines Operator management of MLMD.
                       Setting Deploy to false disables operator reconciliation. Default:
                       true'

--- a/config/internal/apiserver/default/deployment.yaml.tmpl
+++ b/config/internal/apiserver/default/deployment.yaml.tmpl
@@ -84,12 +84,14 @@ spec:
             - name: MOVERESULTS_IMAGE
               value: "{{.APIServer.MoveResultsImage}}"
             ## Env Vars to only include if MLMD Deployed ##
+            {{ if .MLMD }}
             {{ if .MLMD.Deploy }}
             - name: METADATA_GRPC_SERVICE_SERVICE_HOST
               value: "ds-pipeline-metadata-grpc-{{.Name}}.{{.Namespace}}.svc.cluster.local"
             {{ if.MLMD.GRPC.Port }}
             - name: METADATA_GRPC_SERVICE_SERVICE_PORT
               value: "{{.MLMD.GRPC.Port}}"
+            {{ end }}
             {{ end }}
             {{ end }}
             - name: ML_PIPELINE_SERVICE_HOST

--- a/controllers/dspipeline_params.go
+++ b/controllers/dspipeline_params.go
@@ -384,6 +384,17 @@ func (p *DSPAParams) SetupObjectParams(ctx context.Context, dsp *dspa.DataScienc
 }
 
 func (p *DSPAParams) SetupMLMD(ctx context.Context, dsp *dspa.DataSciencePipelinesApplication, client client.Client, log logr.Logger) error {
+	if p.UsingV2Pipelines(dsp) {
+		if p.MLMD == nil {
+			log.Info("MLMD not specified, but is a required component for V2 Pipelines. Including MLMD with default specs.")
+			p.MLMD = &dspa.MLMD{
+				Deploy: true,
+			}
+		} else {
+			log.Info("MLMD disabled in DSPA, but is a required component for V2 Pipelines. Overriding to enable component")
+			p.MLMD.Deploy = true
+		}
+	}
 	if p.MLMD != nil {
 		MlmdEnvoyImagePath := p.GetImageForComponent(dsp, config.MlmdEnvoyImagePath, config.MlmdEnvoyImagePathV2Argo, config.MlmdEnvoyImagePathV2Tekton)
 		MlmdGRPCImagePath := p.GetImageForComponent(dsp, config.MlmdGRPCImagePath, config.MlmdGRPCImagePathV2Argo, config.MlmdGRPCImagePathV2Tekton)

--- a/controllers/dspipeline_params.go
+++ b/controllers/dspipeline_params.go
@@ -391,8 +391,7 @@ func (p *DSPAParams) SetupMLMD(ctx context.Context, dsp *dspa.DataSciencePipelin
 				Deploy: true,
 			}
 		} else {
-			log.Info("MLMD disabled in DSPA, but is a required component for V2 Pipelines. Overriding to enable component")
-			p.MLMD.Deploy = true
+			return fmt.Errorf("MLMD explicitly disabled in DSPA, but is a required component for V2 Pipelines")
 		}
 	}
 	if p.MLMD != nil {

--- a/controllers/mlmd.go
+++ b/controllers/mlmd.go
@@ -26,7 +26,7 @@ func (r *DSPAReconciler) ReconcileMLMD(dsp *dspav1alpha1.DataSciencePipelinesApp
 
 	log := r.Log.WithValues("namespace", dsp.Namespace).WithValues("dspa_name", dsp.Name)
 
-	if !dsp.Spec.MLMD.Deploy {
+	if (params.MLMD == nil || !params.MLMD.Deploy) && (dsp.Spec.MLMD == nil || !dsp.Spec.MLMD.Deploy) {
 		r.Log.Info("Skipping Application of ML-Metadata (MLMD) Resources")
 		return nil
 	}

--- a/controllers/testdata/declarative/case_0/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_0/expected/created/apiserver_deployment.yaml
@@ -75,10 +75,6 @@ spec:
               value: "ubi-minimal:test0"
             - name: MOVERESULTS_IMAGE
               value: "busybox:test0"
-            - name: METADATA_GRPC_SERVICE_SERVICE_HOST
-              value: "ds-pipeline-metadata-grpc-testdsp0.default.svc.cluster.local"
-            - name: METADATA_GRPC_SERVICE_SERVICE_PORT
-              value: "8080"
             - name: ML_PIPELINE_SERVICE_HOST
               value: ds-pipeline-testdsp0.default.svc.cluster.local
             - name: ML_PIPELINE_SERVICE_PORT_GRPC

--- a/controllers/testdata/declarative/case_2/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_2/expected/created/apiserver_deployment.yaml
@@ -75,10 +75,6 @@ spec:
               value: "ubi-minimal:test2"
             - name: MOVERESULTS_IMAGE
               value: "busybox:test2"
-            - name: METADATA_GRPC_SERVICE_SERVICE_HOST
-              value: "ds-pipeline-metadata-grpc-testdsp2.default.svc.cluster.local"
-            - name: METADATA_GRPC_SERVICE_SERVICE_PORT
-              value: "8080"
             - name: ML_PIPELINE_SERVICE_HOST
               value: ds-pipeline-testdsp2.default.svc.cluster.local
             - name: ML_PIPELINE_SERVICE_PORT_GRPC

--- a/controllers/testdata/declarative/case_3/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_3/expected/created/apiserver_deployment.yaml
@@ -75,10 +75,6 @@ spec:
               value: ubi-minimal:test3
             - name: MOVERESULTS_IMAGE
               value: busybox:test3
-            - name: METADATA_GRPC_SERVICE_SERVICE_HOST
-              value: "ds-pipeline-metadata-grpc-testdsp3.default.svc.cluster.local"
-            - name: METADATA_GRPC_SERVICE_SERVICE_PORT
-              value: "8080"
             - name: ML_PIPELINE_SERVICE_HOST
               value: ds-pipeline-testdsp3.default.svc.cluster.local
             - name: ML_PIPELINE_SERVICE_PORT_GRPC

--- a/controllers/testdata/declarative/case_4/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_4/expected/created/apiserver_deployment.yaml
@@ -75,10 +75,6 @@ spec:
               value: "this-ubi-minimal-image-from-cr-should-be-used:test4"
             - name: MOVERESULTS_IMAGE
               value: "this-busybox-image-from-cr-should-be-used:test4"
-            - name: METADATA_GRPC_SERVICE_SERVICE_HOST
-              value: "ds-pipeline-metadata-grpc-testdsp4.default.svc.cluster.local"
-            - name: METADATA_GRPC_SERVICE_SERVICE_PORT
-              value: "8080"
             - name: ML_PIPELINE_SERVICE_HOST
               value: ds-pipeline-testdsp4.default.svc.cluster.local
             - name: ML_PIPELINE_SERVICE_PORT_GRPC


### PR DESCRIPTION
## Description of your changes:
Requires/Forces MLMD (a required component) to be deployed when using v2 pipelines

## Testing instructions
* Deploy DSPO (re-install CRD, as well)
* Deploy DSPAv1 with no MLMD specified:
* *  Verify MLMD not deployed
* Deploy DSPAv2 with no MLMD specified
* * Verify MLMD is deployed

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
